### PR TITLE
Use upcoming reloadable turret API from CombatExtended

### DIFF
--- a/Source/PatchCE/WeaponBase_CE_Building_TurretWeaponBase.cs
+++ b/Source/PatchCE/WeaponBase_CE_Building_TurretWeaponBase.cs
@@ -8,97 +8,99 @@ using Verse;
 using Verse.AI;
 using Verse.Sound;
 using RimWorld;
+
+using CombatExtended;
+using CombatExtended.Compatibility;
+
 //using RimWorld.Planet;
 //using RimWorld.SquadAI;
 
 namespace Patches_Misc_CE
 {
+    [StaticConstructorOnStartup]
     public class WeaponBase_CE_Building_TurretWeaponBase : TurretWeaponBase.Building_TurretWeaponBase
     {
+	private bool _reloading = false;
+	private CompAmmoUser _ammo;
+	private CompFireModes compFireModes = null;
 
-        protected override void BeginBurst()
-        {
-            if (this._sourceVerb == null)
-                this._sourceVerb = GunCompEq.PrimaryVerb;
+	static WeaponBase_CE_Building_TurretWeaponBase() {
+	    TurretRegistry.RegisterReloadableTurret(typeof(WeaponBase_CE_Building_TurretWeaponBase),
+						    ((Building_Turret t, bool r) => {(t as WeaponBase_CE_Building_TurretWeaponBase).SetReload(r);}),
+						    ((Building_Turret t) => {return (t as WeaponBase_CE_Building_TurretWeaponBase).GetReload();}),
+						    ((Building_Turret t) => {return (t as WeaponBase_CE_Building_TurretWeaponBase).GetGun();}),
+						    ((Building_Turret t) => {return (t as WeaponBase_CE_Building_TurretWeaponBase).GetAmmo();}));
+	}
+      
+	private CompAmmoUser GetAmmo() {
+	    if (_ammo == null) {
+		_ammo = GetGun()?.TryGetComp<CompAmmoUser>();
+		if (_ammo!=null) {
+		    _ammo.turret = this;
+		}
+	    }
+	    return _ammo;
+	}
 
-            //GunCompEq.PrimaryVerb.TryStartCastOn(CurrentTarget, false, true);
-            this.TryStartCastOn(Verb, CurrentTarget, false, true);
-            base.OnAttackedTarget(this.CurrentTarget);
-        }
+	private Thing GetGun() {
+	    return gun;
+	}
 
-        public bool TryStartCastOn(Verb verb, LocalTargetInfo castTarg, bool surpriseAttack = false, bool canHitNonTargetPawns = true)
-        {
-            if (verb.caster == null)
-            {
-                Log.Error("Verb " + this.GetUniqueLoadID() + " needs caster to work (possibly lost during saving/loading).", false);
-                return false;
-            }
-            if (!verb.caster.Spawned)
-            {
-                return false;
-            }
-            if (verb.state == VerbState.Bursting || !verb.CanHitTarget(castTarg))
-            {
-                return false;
-            }
+	private void SetReload(bool reloading) {
+	    _reloading = reloading;
+	}
 
-            Patches_Misc_CE.Reflect<Boolean>.SetValue(verb, "surpriseAttack", surpriseAttack);
-            Patches_Misc_CE.Reflect<Boolean>.SetValue(verb, "canHitNonTargetPawnsNow", canHitNonTargetPawns);
-            Patches_Misc_CE.Reflect<LocalTargetInfo>.SetValue(verb, "currentTarget", castTarg);
+	private bool GetReload() {
+	    return _reloading;
+	}
 
-            //verb.surpriseAttack = surpriseAttack;
-            //verb.canHitNonTargetPawnsNow = canHitNonTargetPawns;
-            //verb.currentTarget = castTarg;
 
-            if (verb.CasterIsPawn && verb.verbProps.warmupTime > 0f)
-            {
-                ShootLine newShootLine;
-                if (!verb.TryFindShootLineFromTo(verb.caster.Position, castTarg, out newShootLine))
+	public CompFireModes CompFireModes
+	{
+	    get
+	    {
+		if (compFireModes == null && gun != null) compFireModes = gun.TryGetComp<CompFireModes>();
+		return compFireModes;
+	    }
+	}
+
+	public override void SpawnSetup(Map map, bool respawningAfterLoad) {
+	    base.SpawnSetup(map, respawningAfterLoad);
+	    Map.GetComponent<TurretTracker>().Register(this);
+
+	}
+	public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish) {
+	    Map.GetComponent<TurretTracker>().Unregister(this);
+            base.DeSpawn(mode);
+
+	}
+
+	public override IEnumerable<Gizmo> GetGizmos() {
+	    foreach (var c in base.GetGizmos())
+		yield return c;
+	    var ammo = GetAmmo();
+	    if (ammo!=null) {
+		foreach (Command com in ammo.CompGetGizmosExtra())
+		{
+		    if (base.Faction != Faction.OfPlayer && Prefs.DevMode && com is GizmoAmmoStatus)
+			(com as GizmoAmmoStatus).prefix = "DEV: ";
+		  
+		    yield return com;
+		}
+	      
+	    }
+	    if (gun!=null) {
+		if (CompFireModes != null)
                 {
-                    return false;
-                }
-                verb.CasterPawn.Drawer.Notify_WarmingCastAlongLine(newShootLine, verb.caster.Position);
-                float statValue = verb.CasterPawn.GetStatValue(StatDefOf.AimingDelayFactor, true);
-                int ticks = (verb.verbProps.warmupTime * statValue).SecondsToTicks();
-                verb.CasterPawn.stances.SetStance(new Stance_Warmup(ticks, castTarg, verb));
-            }
-            else
-            {
-                verb.WarmupComplete();
-            }
-            return true;
-        }
-
-
-        private Verb _sourceVerb;
-        private Verb_Shoot _verb;
-        public Verb_Shoot Verb
-        {
-            get
-            {
-                if (_verb == null && _sourceVerb != null)
-                {
-                    _verb = new Verb_Shoot();
-                    this.InitVerb(this._verb, _sourceVerb.verbProps, _sourceVerb.verbTracker, null, null, null);
+                    foreach (Command com in CompFireModes.GenerateGizmos())
+                    {
+                        yield return com;
+                    }
                 }
 
-                return _verb;
-            }
-            set
-            {
-                _verb = value;
-            }
-        }
+	    }
 
-        private void InitVerb(Verb verb, VerbProperties properties, VerbTracker verbTracker, Tool tool, ManeuverDef maneuver, string id)
-        {
-            verb.loadID = id;
-            verb.verbProps = properties;
-            verb.verbTracker = verbTracker;
-            verb.tool = tool;
-            verb.maneuver = maneuver;
-            verb.caster = this;
-        }
-
+	}
+    
     }
 }

--- a/Source/PatchCE/WeaponBase_CE_Building_TurretWeaponBase.cs
+++ b/Source/PatchCE/WeaponBase_CE_Building_TurretWeaponBase.cs
@@ -83,7 +83,13 @@ namespace Patches_Misc_CE
 
 	}
 
-
+	public override void Tick() {
+	    if (_reloading) {
+		return;
+	    }
+	    base.Tick();
+	}
+	
 	public static void Postfix(TurretWeaponBase.Building_TurretWeaponBase __instance, ref int ___burstWarmupTicksLeft) {
 	    Verb attackVerb = __instance.AttackVerb;
 	    if (___burstWarmupTicksLeft == __instance.def.building.turretBurstWarmupTime.SecondsToTicks()) {


### PR DESCRIPTION
As promised in the other repository, here's the compatibility patch for Combat Extended to make the turret base work properly.  I'm not sure why you were using reflection on the `Verb`, so I didn't reimplement it (so far, everything appears to work).  If there is a reason for it, I'll probably add it to the new public API on the CE side (since if you need it, odds are good other mods will too).

One important note is that the new API on the CE side has not landed yet.  If you want to wait on that, I'll let you know when it does.  Otherwise, it's CombatExtended-Continued/CombatExtended#317 if you want to try it out *before* it lands in a public release.

Anyway, this version doesn't require any changes to `TurretWeaponBase.Building_TurretWeaponBase`, it adds the state tracking in the subclass.  If you want to simplify it considerably, the only state that needs tracking on the turret's class is when it is reloading.  The rest can be easily done in an extension class, which can either live in this repo or get folded into CE's repo.  Since that wouldn't require a subclass, it wouldn't require patching the xml, or rebuilding existing turrets.